### PR TITLE
Device handlers support new DNI format

### DIFF
--- a/devicetypes/verbem/domoticzblinds.src/domoticzblinds.groovy
+++ b/devicetypes/verbem/domoticzblinds.src/domoticzblinds.groovy
@@ -193,6 +193,8 @@ private getIDXAddress() {
         def parts = device.deviceNetworkId.split(":")
         if (parts.length == 3) {
             idx = parts[2]
+		}else if(parts.length == 2 && parts[0].endsWith('-IDX')){
+			idx = parts[1]
         } else {
             log.warn "Can't figure out idx for device: ${device.id}"
         }

--- a/devicetypes/verbem/domoticzonoff.src/domoticzonoff.groovy
+++ b/devicetypes/verbem/domoticzonoff.src/domoticzonoff.groovy
@@ -193,6 +193,8 @@ private getIDXAddress() {
         def parts = device.deviceNetworkId.split(":")
         if (parts.length == 3) {
             idx = parts[2]
+		}else if(parts.length == 2 && parts[0].endsWith('-IDX')){
+			idx = parts[1]
         } else {
             log.warn "Can't figure out idx for device: ${device.id}"
         }


### PR DESCRIPTION
Recent change to the device network ID format broke newly added devices as the handlers expected two : symbols and the new format only has one.

This could also be fixed by changing the -IDX to :IDX in the smart app. I was not really sure which route you would go so this is my best guess.
